### PR TITLE
Update json requirement from ~> 1.8 to >= 1.8, < 3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,24 @@
 PATH
   remote: .
   specs:
-    mongoid-simple-tags (0.1.2)
-      json (~> 1.8)
+    mongoid-simple-tags (0.1.3)
+      json (>= 1.8, < 3.0)
       mongoid (>= 3.0.3)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.2.13)
-      activesupport (= 3.2.13)
-      builder (~> 3.0.0)
-    activesupport (3.2.13)
-      i18n (= 0.6.1)
-      multi_json (~> 1.0)
-    builder (3.0.4)
+    activemodel (6.0.3.2)
+      activesupport (= 6.0.3.2)
+    activesupport (6.0.3.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    bson (4.10.0)
     colorize (0.5.8)
+    concurrent-ruby (1.1.6)
     coveralls (0.6.7)
       colorize
       multi_json (~> 1.3)
@@ -23,17 +26,17 @@ GEM
       simplecov (>= 0.7)
       thor
     diff-lcs (1.2.4)
-    i18n (0.6.1)
-    json (1.8.0)
+    i18n (1.8.5)
+      concurrent-ruby (~> 1.0)
+    json (2.3.1)
     mime-types (1.23)
-    mongoid (3.1.4)
-      activemodel (~> 3.2)
-      moped (~> 1.4)
-      origin (~> 1.0)
-      tzinfo (~> 0.3.22)
-    moped (1.5.0)
+    minitest (5.14.1)
+    mongo (2.12.2)
+      bson (>= 4.8.2, < 5.0.0)
+    mongoid (7.1.2)
+      activemodel (>= 5.1, < 6.1)
+      mongo (>= 2.7.0, < 3.0.0)
     multi_json (1.7.3)
-    origin (1.1.0)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rspec (2.13.0)
@@ -49,7 +52,10 @@ GEM
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
     thor (0.18.1)
-    tzinfo (0.3.37)
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby

--- a/mongoid-simple-tags.gemspec
+++ b/mongoid-simple-tags.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_development_dependency "rspec", "~> 2.13.0"
   s.add_dependency "mongoid", ">= 3.0.3"
-  s.add_dependency "json", "~> 1.8"
+  s.add_dependency "json", ">= 1.8", "< 3.0"
 
 end


### PR DESCRIPTION
(Original pull request: https://github.com/hashdog/mongoid-simple-tags/pull/27)

Updates the requirements on [json](https://github.com/flori/json) to permit the latest version.
- [Release notes](https://github.com/flori/json/releases)
- [Changelog](https://github.com/flori/json/blob/master/CHANGES.md)
- [Commits](https://github.com/flori/json/compare/v1.8.0...v2.3.1)

Signed-off-by: dependabot[bot] <support@github.com>